### PR TITLE
UI and fonts

### DIFF
--- a/SiraLocalizer/HarmonyPatches/TextSegmentedControl.cs
+++ b/SiraLocalizer/HarmonyPatches/TextSegmentedControl.cs
@@ -1,0 +1,28 @@
+﻿using HarmonyLib;
+using HMUI;
+using TMPro;
+using UnityEngine;
+
+namespace SiraLocalizer.HarmonyPatches
+{
+    [HarmonyPatch(typeof(TextSegmentedControl), "InstantiateCell", MethodType.Normal)]
+    internal static class TextSegmentedControl_InstantiateCell
+    {
+        public static void Postfix(TextSegmentedControlCell __result)
+        {
+            CurvedTextMeshPro text = __result.transform.Find("Text").GetComponent<CurvedTextMeshPro>();
+
+            if (text.alignment != TextAlignmentOptions.Midline) return;
+
+            // Midline text alignment breaks if certain characters are taller than others
+            // e.g. the accent on É makes it taller than regular ASCII letters
+            text.alignment = TextAlignmentOptions.Baseline;
+
+            // this value is eyeballed
+            Vector2 offset = new Vector2(0, 0.3f * text.fontSize);
+
+            text.rectTransform.offsetMin -= offset;
+            text.rectTransform.offsetMax -= offset;
+        }
+    }
+}

--- a/SiraLocalizer/Installers/SiraLocalizerCoreInstaller.cs
+++ b/SiraLocalizer/Installers/SiraLocalizerCoreInstaller.cs
@@ -1,4 +1,5 @@
-﻿using Zenject;
+﻿using SiraLocalizer.UI;
+using Zenject;
 using SiraUtil.Interfaces;
 
 namespace SiraLocalizer.Installers
@@ -9,6 +10,9 @@ namespace SiraLocalizer.Installers
         {
             Container.Bind<ILocalizer>().WithId("SIRA.Localizer").To<Localizer>().AsSingle();
             Container.Bind<IInitializable>().To<CustomLocaleLoader>().AsSingle();
+
+            Container.BindInterfacesAndSelfTo<LanguageManager>().AsSingle().NonLazy();
+            Container.BindInterfacesAndSelfTo<FontLoader>().AsSingle().NonLazy();
         }
     }
 }

--- a/SiraLocalizer/Installers/SiraLocalizerUIInstaller.cs
+++ b/SiraLocalizer/Installers/SiraLocalizerUIInstaller.cs
@@ -1,0 +1,13 @@
+﻿using SiraLocalizer.UI;
+using Zenject;
+
+namespace SiraLocalizer.Installers
+{
+    internal class SiraLocalizerUIInstaller : Installer
+    {
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesAndSelfTo<LanguageSettingCreator>().AsSingle().NonLazy();
+        }
+    }
+}

--- a/SiraLocalizer/Plugin.cs
+++ b/SiraLocalizer/Plugin.cs
@@ -15,6 +15,7 @@ namespace SiraLocalizer
         {
             Log = logger;
             zenjector.OnApp<SiraLocalizerCoreInstaller>();
+            zenjector.OnMenu<SiraLocalizerUIInstaller>();
         }
 
         [OnEnable, OnDisable]

--- a/SiraLocalizer/Plugin.cs
+++ b/SiraLocalizer/Plugin.cs
@@ -1,6 +1,8 @@
-﻿using IPA;
+﻿using HarmonyLib;
+using IPA;
 using SiraUtil.Zenject;
 using SiraLocalizer.Installers;
+using System.Reflection;
 using IPALogger = IPA.Logging.Logger;
 
 namespace SiraLocalizer
@@ -8,17 +10,33 @@ namespace SiraLocalizer
     [Plugin(RuntimeOptions.DynamicInit)]
     public class Plugin
     {
+        private const string kHarmonyId = "dev.auros.siralocalizer";
+
         internal static IPALogger Log { get; private set; }
+
+        private readonly Harmony _harmony;
 
         [Init]
         public Plugin(IPALogger logger, Zenjector zenjector)
         {
             Log = logger;
+
+            _harmony = new Harmony(kHarmonyId);
+
             zenjector.OnApp<SiraLocalizerCoreInstaller>();
             zenjector.OnMenu<SiraLocalizerUIInstaller>();
         }
 
-        [OnEnable, OnDisable]
-        public void OnState() { }
+        [OnEnable]
+        public void OnEnable()
+        {
+            _harmony.PatchAll(Assembly.GetExecutingAssembly());
+        }
+
+        [OnDisable]
+        public void OnDisable()
+        {
+            _harmony.UnpatchAll(kHarmonyId);
+        }
     }
 }

--- a/SiraLocalizer/SiraLocalizer.csproj
+++ b/SiraLocalizer/SiraLocalizer.csproj
@@ -60,6 +60,10 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Harmony">
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Main">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
@@ -121,6 +125,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CustomLocaleLoader.cs" />
+    <Compile Include="HarmonyPatches\TextSegmentedControl.cs" />
     <Compile Include="Installers\SiraLocalizerCoreInstaller.cs" />
     <Compile Include="Installers\SiraLocalizerUIInstaller.cs" />
     <Compile Include="UI\FontLoader.cs" />

--- a/SiraLocalizer/SiraLocalizer.csproj
+++ b/SiraLocalizer/SiraLocalizer.csproj
@@ -84,6 +84,10 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.AssetBundleModule">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
@@ -118,12 +122,18 @@
   <ItemGroup>
     <Compile Include="CustomLocaleLoader.cs" />
     <Compile Include="Installers\SiraLocalizerCoreInstaller.cs" />
+    <Compile Include="Installers\SiraLocalizerUIInstaller.cs" />
+    <Compile Include="UI\FontLoader.cs" />
+    <Compile Include="UI\LanguageManager.cs" />
+    <Compile Include="UI\LanguageSetting.cs" />
+    <Compile Include="UI\LanguageSettingCreator.cs" />
     <Compile Include="Localizer.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="manifest.json" />
+    <EmbeddedResource Include="Resources\fonts.assets" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />

--- a/SiraLocalizer/UI/FontLoader.cs
+++ b/SiraLocalizer/UI/FontLoader.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TMPro;
+using UnityEngine;
+using Zenject;
+using Object = UnityEngine.Object;
+
+namespace SiraLocalizer.UI
+{
+    internal class FontLoader : IInitializable, IDisposable
+    {
+        private static readonly string kLatin1SupplementFontName = "Teko-Medium SDF Latin-1 Supplement";
+        private static readonly string kSimplifiedChineseFontName = "SourceHanSansSC-Medium SDF";
+
+        private static readonly string[] kTargetFontNames = { "Teko-Medium SDF", "Teko-Medium SDF No Glow", "Teko-Medium SDF No Glow Billboard" };
+        private static readonly string[] kFontNamesToRemove = { kLatin1SupplementFontName, kSimplifiedChineseFontName, "SourceHanSansCN-Bold-SDF-Common-1(2k)", "SourceHanSansCN-Bold-SDF-Common-2(2k)", "SourceHanSansCN-Bold-SDF-Uncommon(2k)" };
+
+        private readonly GameScenesManager _gameScenesManager;
+        
+        private readonly List<TMP_FontAsset> _fallbackFontAssets = new List<TMP_FontAsset>();
+
+        private FontLoader(GameScenesManager gameScenesManager)
+        {
+            _gameScenesManager = gameScenesManager;
+        }
+
+        public void Initialize()
+        {
+            _gameScenesManager.transitionDidFinishEvent += OnTransitionDidFinish;
+
+            SharedCoroutineStarter.instance.StartCoroutine(LoadFontAssets());
+        }
+
+        public void Dispose()
+        {
+            _gameScenesManager.transitionDidFinishEvent -= OnTransitionDidFinish;
+        }
+
+        private void OnTransitionDidFinish(ScenesTransitionSetupDataSO setupData, DiContainer container)
+        {
+            AddFallbackFonts();
+        }
+
+        private IEnumerator LoadFontAssets()
+        {
+            Plugin.Log.Info($"Loading fonts");
+
+            AssetBundleCreateRequest assetBundleCreateRequest = AssetBundle.LoadFromStreamAsync(Assembly.GetExecutingAssembly().GetManifestResourceStream("SiraLocalizer.Resources.fonts.assets"));
+            yield return assetBundleCreateRequest;
+
+            AssetBundle assetBundle = assetBundleCreateRequest.assetBundle;
+
+            if (!assetBundleCreateRequest.isDone || !assetBundle)
+            {
+                Plugin.Log.Error("Failed to load fonts asset bundle; some characters may not display as expected");
+                yield break;
+            }
+
+            AddFont(assetBundle, kLatin1SupplementFontName);
+            AddFont(assetBundle, kSimplifiedChineseFontName);
+
+            assetBundle.Unload(false);
+
+            AddFallbackFonts();
+        }
+
+        private void AddFont(AssetBundle assetBundle, string name)
+        {
+            TMP_FontAsset fontAsset = assetBundle.LoadAsset<TMP_FontAsset>(name);
+
+            if (fontAsset == null)
+            {
+                Plugin.Log.Error($"Font '{name}' could not be loaded; some characters may not display as expected");
+                return;
+            }
+
+            Plugin.Log.Info($"Font '{name}' loaded successfully");
+
+            _fallbackFontAssets.Add(fontAsset);
+        }
+
+        private void AddFallbackFonts()
+        {
+            if (_fallbackFontAssets == null) return;
+
+            IEnumerable<TMP_FontAsset> originalFontAssets = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().Where(f => kTargetFontNames.Contains(f.name));
+
+            foreach (TMP_FontAsset fontAsset in originalFontAssets)
+            {
+                ApplyFallbacks(fontAsset, _fallbackFontAssets);
+            }
+
+            // force update any text that has already rendered
+            foreach (TMP_Text text in Object.FindObjectsOfType<TMP_Text>())
+            {
+                text.SetAllDirty();
+            }
+        }
+
+        private void ApplyFallbacks(TMP_FontAsset fontAsset, IList<TMP_FontAsset> fallbacks)
+        {
+            Plugin.Log.Info($"Adding fallbacks to '{fontAsset.name}' ({(uint)fontAsset.GetHashCode()})");
+
+            fontAsset.fallbackFontAssetTable.RemoveAll(f => kFontNamesToRemove.Contains(f.name));
+
+            foreach (TMP_FontAsset fallback in fallbacks.Reverse())
+            {
+                TMP_FontAsset fallbackCopy = Object.Instantiate(fallback);
+
+                fallbackCopy.name = fallback.name;
+                fallbackCopy.material.shader = fontAsset.material.shader;
+                fallbackCopy.material.shaderKeywords = fontAsset.material.shaderKeywords;
+
+                // insert as first possible fallback fonts
+                fontAsset.fallbackFontAssetTable.Insert(0, fallbackCopy);
+            }
+        }
+    }
+}

--- a/SiraLocalizer/UI/LanguageManager.cs
+++ b/SiraLocalizer/UI/LanguageManager.cs
@@ -1,0 +1,79 @@
+﻿using IPA.Utilities;
+using Polyglot;
+using System;
+using System.IO;
+using Zenject;
+
+namespace SiraLocalizer.UI
+{
+    internal class LanguageManager : IInitializable, IDisposable, ILocalize
+    {
+        private static readonly string kSettingsFilePath = Path.Combine(UnityGame.UserDataPath, "language");
+
+        public Language selectedLanguage;
+
+        public void Initialize()
+        {
+            Localization.Instance.AddOnLocalizeEvent(this);
+
+            LoadLanguageFromFile();
+        }
+
+        public void Dispose()
+        {
+            Localization.Instance.RemoveOnLocalizeEvent(this);
+
+            SaveLanguageToFile();
+        }
+
+        public void OnLocalize()
+        {
+            // enforce our language selection
+            if (Localization.Instance.SelectedLanguage != selectedLanguage)
+            {
+                Plugin.Log.Trace("Enforcing language " + selectedLanguage);
+                Localization.Instance.SelectLanguage(selectedLanguage);
+            }
+        }
+
+        private void LoadLanguageFromFile()
+        {
+            if (!File.Exists(kSettingsFilePath)) return;
+
+            try
+            {
+                using (var reader = new StreamReader(kSettingsFilePath))
+                {
+                    if (!Enum.TryParse(reader.ReadToEnd(), out Language language)) return;
+                    if (!Localization.Instance.SupportedLanguages.Contains(selectedLanguage)) return;
+
+                    selectedLanguage = language;
+
+                    Plugin.Log.Info("Set language to " + selectedLanguage);
+                    Localization.Instance.SelectLanguage(selectedLanguage);
+                }
+            }
+            catch (IOException ex)
+            {
+                Plugin.Log.Error("Failed to load language from settings");
+                Plugin.Log.Error(ex);
+            }
+        }
+
+        private void SaveLanguageToFile()
+        {
+            try
+            {
+                using (var writer = new StreamWriter(kSettingsFilePath))
+                {
+                    writer.Write(selectedLanguage.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.Error("Failed to save language to settings");
+                Plugin.Log.Error(ex);
+            }
+        }
+    }
+}

--- a/SiraLocalizer/UI/LanguageSetting.cs
+++ b/SiraLocalizer/UI/LanguageSetting.cs
@@ -1,0 +1,71 @@
+﻿using HMUI;
+using Polyglot;
+using System.Collections.Generic;
+using UnityEngine;
+using Zenject;
+
+namespace SiraLocalizer.UI
+{
+    internal class LanguageSetting : MonoBehaviour
+    {
+        private LanguageManager _languageManager;
+
+        private SimpleTextDropdown _dropdown;
+        private SettingsNavigationController _settingsNavigationController;
+
+        private Language _selectedLanguage;
+
+        private IReadOnlyList<Language> _languages;
+        private IReadOnlyList<string> _languageDisplayNames;
+
+        [Inject]
+        public void Construct(LanguageManager languageManager)
+        {
+            _languageManager = languageManager;
+        }
+
+        public void Awake()
+        {
+            _dropdown = GetComponentInChildren<SimpleTextDropdown>();
+            _settingsNavigationController = GetComponentInParent<SettingsNavigationController>();
+
+            // AsReadOnly to avoid accidentally messing around with values inside Polyglot
+            _languages = Localization.Instance.SupportedLanguages.AsReadOnly();
+            _languageDisplayNames = Localization.Instance.LocalizedLanguageNames.AsReadOnly();
+
+            _selectedLanguage = _languageManager.selectedLanguage;
+        }
+
+        public void OnEnable()
+        {
+            _settingsNavigationController.didFinishEvent += OnSettingsDidFinish;
+            _dropdown.didSelectCellWithIdxEvent += OnSelectedCell;
+
+            _dropdown.SetTexts(_languageDisplayNames);
+            _dropdown.SelectCellWithIdx(_languages.IndexOf(_selectedLanguage));
+        }
+
+        public void OnDisable()
+        {
+            _settingsNavigationController.didFinishEvent -= OnSettingsDidFinish;
+            _dropdown.didSelectCellWithIdxEvent -= OnSelectedCell;
+        }
+
+        private void OnSettingsDidFinish(SettingsNavigationController.FinishAction finishAction)
+        {
+            if (finishAction == SettingsNavigationController.FinishAction.Cancel)
+            {
+                _selectedLanguage = _languageManager.selectedLanguage;
+            }
+            else
+            {
+                _languageManager.selectedLanguage = _selectedLanguage;
+            }
+        }
+
+        private void OnSelectedCell(DropdownWithTableView dropdown, int idx)
+        {
+            _selectedLanguage = _languages[idx];
+        }
+    }
+}

--- a/SiraLocalizer/UI/LanguageSettingCreator.cs
+++ b/SiraLocalizer/UI/LanguageSettingCreator.cs
@@ -1,0 +1,57 @@
+﻿using Polyglot;
+using UnityEngine;
+using Zenject;
+
+namespace SiraLocalizer.UI
+{
+    internal class LanguageSettingCreator : IInitializable
+    {
+        private readonly DiContainer _container;
+        private readonly SettingsNavigationController _settingsNavigationController;
+        private readonly GameplaySetupViewController _gameplaySetupViewController;
+
+        private LanguageSettingCreator(DiContainer container, SettingsNavigationController settingsNavigationController, GameplaySetupViewController gameplaySetupViewController)
+        {
+            _container = container;
+            _settingsNavigationController = settingsNavigationController;
+            _gameplaySetupViewController = gameplaySetupViewController;
+        }
+
+        public void Initialize()
+        {
+            AddMenuOption();
+        }
+
+        private void AddMenuOption()
+        {
+            Transform dropdownTemplate = _gameplaySetupViewController.transform.Find("EnvironmentOverrideSettings/Settings/Elements/NormalLevels");
+            Transform otherSettingsContent = _settingsNavigationController.transform.Find("OtherSettings/Content");
+
+            if (!dropdownTemplate)
+            {
+                Plugin.Log.Error("Dropdown template not found!");
+                return;
+            }
+
+            if (!otherSettingsContent)
+            {
+                Plugin.Log.Error("OtherSettings/Content not found!");
+                return;
+            }
+
+            GameObject gameObject = _container.InstantiatePrefab(dropdownTemplate.gameObject, otherSettingsContent);
+            gameObject.name = "LanguageSetting";
+
+            RectTransform rectTransform = gameObject.GetComponent<RectTransform>();
+            rectTransform.offsetMin = new Vector2(0, -21.4f);
+            rectTransform.offsetMax = new Vector2(0, -14.4f);
+
+            LocalizedTextMeshProUGUI label = gameObject.transform.Find("Label").GetComponent<LocalizedTextMeshProUGUI>();
+            label.Key = "SETTINGS_LANGUAGE";
+
+            _container.InstantiateComponent<LanguageSetting>(gameObject);
+
+            Plugin.Log.Info("Created language setting");
+        }
+    }
+}


### PR DESCRIPTION
This adds a few things:
* Language setting under *Settings* > *Other*.
* Fallback font for accented characters.
* Replacement font for Simplified Chinese characters (base game's font is broken).
* Fix for `TextSegmentedControl` components that use Midline text alignment. I decided to only do this for the `TextSegmentedControl` components for two reasons:
   1. They are one of the only things that *definitely* don't look right when alignment is off since text is expected to be aligned across all cells but they are internally aligned separately
   2. Applying this to everything else would require calls to `Resources.FindObjectsOfTypeAll`